### PR TITLE
Refactor: correct method names: xx_keys should be xx_digests

### DIFF
--- a/benches/xor_bench.rs
+++ b/benches/xor_bench.rs
@@ -27,13 +27,13 @@ fn generate_unique_keys(rng: &mut StdRng, size: usize) -> Vec<u64> {
     keys
 }
 
-fn bench_xor8_populate_keys(c: &mut Criterion) {
+fn bench_xor8_populate_digests(c: &mut Criterion) {
     let seed: u64 = random();
     let mut rng = StdRng::seed_from_u64(seed);
 
     let keys = generate_unique_keys(&mut rng, SIZE);
 
-    c.bench_function("xor8_populate_keys", |b| {
+    c.bench_function("xor8_populate_digests", |b| {
         b.iter(|| {
             let mut filter = Xor8::<RandomState>::new();
             filter.populate_keys(&keys);
@@ -42,16 +42,16 @@ fn bench_xor8_populate_keys(c: &mut Criterion) {
     });
 }
 
-fn bench_xor8_build_keys(c: &mut Criterion) {
+fn bench_xor8_build_from_digests(c: &mut Criterion) {
     let seed: u64 = random();
     let mut rng = StdRng::seed_from_u64(seed);
 
     let keys = generate_unique_keys(&mut rng, SIZE);
 
-    c.bench_function("xor8_build_keys", |b| {
+    c.bench_function("xor8_build_from_digests", |b| {
         b.iter(|| {
             let mut filter = Xor8::<RandomState>::new();
-            filter.build_keys(&keys).expect("failed build");
+            filter.build_from_digests(&keys).expect("failed build");
         })
     });
 }
@@ -108,7 +108,7 @@ fn bench_xor8_contains(c: &mut Criterion) {
     });
 }
 
-fn bench_xor8_contains_key(c: &mut Criterion) {
+fn bench_xor8_contains_digest(c: &mut Criterion) {
     let seed: u64 = random();
     let mut rng = StdRng::seed_from_u64(seed);
 
@@ -122,9 +122,9 @@ fn bench_xor8_contains_key(c: &mut Criterion) {
     };
 
     let mut n = 0;
-    c.bench_function("xor8_contains_key", |b| {
+    c.bench_function("xor8_contains_digest", |b| {
         b.iter(|| {
-            filter.contains_key(keys[n % keys.len()]);
+            filter.contains_digest(keys[n % keys.len()]);
             n += 1;
         })
     });
@@ -132,12 +132,12 @@ fn bench_xor8_contains_key(c: &mut Criterion) {
 
 criterion_group!(
     benches,
-    bench_xor8_populate_keys,
-    bench_xor8_build_keys,
+    bench_xor8_populate_digests,
+    bench_xor8_build_from_digests,
     bench_xor8_populate,
     bench_xor8_insert,
     bench_xor8_contains,
-    bench_xor8_contains_key,
+    bench_xor8_contains_digest,
 );
 
 criterion_main!(benches);

--- a/src/xor8.rs
+++ b/src/xor8.rs
@@ -176,8 +176,10 @@ impl<H> Xor8<H>
 where
     H: BuildHasher,
 {
-    /// Insert 64-bit digest of a single key. Digest for the key shall be generated
-    /// using the default-hasher or via hasher supplied via [Xor8::with_hasher] method.
+    /// Insert 64-bit digest of a single key.
+    ///
+    /// Digest for the key shall be generated using the default-hasher or via hasher supplied via
+    /// [Xor8::with_hasher] method.
     pub fn insert<K: ?Sized + Hash>(&mut self, key: &K) {
         let hashed_key = {
             let mut hasher = self.hash_builder.build_hasher();
@@ -190,9 +192,10 @@ where
         self.keys.as_mut().unwrap().insert(hashed_key, ());
     }
 
-    /// Populate with 64-bit digests for a collection of keys of type `K`. Digest for
-    /// key shall be generated using the default-hasher or via hasher supplied
-    /// via [Xor8::with_hasher] method.
+    /// Populate with 64-bit digests for a collection of keys of type `K`.
+    ///
+    /// Digest for key shall be generated using the default-hasher or via hasher supplied via
+    /// [Xor8::with_hasher] method.
     pub fn populate<K: Hash>(&mut self, keys: &[K]) {
         if let Some(x) = self.num_keys.as_mut() {
             *x += keys.len()
@@ -225,19 +228,19 @@ where
         match self.keys.take() {
             Some(keys) => {
                 let digests = keys.iter().map(|(k, _)| *k).collect::<Vec<u64>>();
-                self.build_keys(&digests)
+                self.build_from_digests(&digests)
             }
             None => Ok(()),
         }
     }
 
-    /// Build a bitmap for pre-computed 64-bit digests for keys. If keys where
-    /// previously inserted using [Xor8::insert] or [Xor8::populate] or
+    /// Build a bitmap for pre-computed 64-bit digests for keys.
+    ///
+    /// If keys where previously inserted using [Xor8::insert] or [Xor8::populate] or
     /// [Xor8::populate_keys] methods, they shall be ignored.
     ///
-    /// It is upto the caller to ensure that digests are unique, that there no
-    /// duplicates.
-    pub fn build_keys(&mut self, digests: &[u64]) -> Result<()> {
+    /// It is upto the caller to ensure that digests are unique, that there no duplicates.
+    pub fn build_from_digests(&mut self, digests: &[u64]) -> Result<()> {
         self.num_keys = Some(digests.len());
         let (size, mut rngcounter) = (digests.len(), 1_u64);
         let capacity = {
@@ -259,7 +262,7 @@ where
 
         loop {
             for key in digests.iter() {
-                let hs = self.geth0h1h2(*key);
+                let hs = self.get_h0h1h2(*key);
                 sets0[hs.h0 as usize].xor_mask ^= hs.h;
                 sets0[hs.h0 as usize].count += 1;
                 sets1[hs.h1 as usize].xor_mask ^= hs.h;
@@ -309,8 +312,8 @@ where
                         continue;
                     }
                     let hash = keyindexvar.hash;
-                    let h1 = self.geth1(hash);
-                    let h2 = self.geth2(hash);
+                    let h1 = self.get_h1(hash);
+                    let h2 = self.get_h2(hash);
                     stack.push(keyindexvar);
 
                     let mut s = unsafe { sets1.get_unchecked_mut(h1 as usize) };
@@ -338,8 +341,8 @@ where
                         continue;
                     }
                     let hash = keyindexvar.hash;
-                    let h0 = self.geth0(hash);
-                    let h2 = self.geth2(hash);
+                    let h0 = self.get_h0(hash);
+                    let h2 = self.get_h2(hash);
                     keyindexvar.index += self.block_length;
                     stack.push(keyindexvar);
 
@@ -368,8 +371,8 @@ where
                         continue;
                     }
                     let hash = keyindexvar.hash;
-                    let h0 = self.geth0(hash);
-                    let h1 = self.geth1(hash);
+                    let h0 = self.get_h0(hash);
+                    let h1 = self.get_h1(hash);
                     keyindexvar.index += 2 * self.block_length;
                     stack.push(keyindexvar);
 
@@ -413,16 +416,16 @@ where
         while let Some(ki) = stack.pop() {
             let mut val = fingerprint(ki.hash) as u8;
             if ki.index < self.block_length {
-                let h1 = (self.geth1(ki.hash) + self.block_length) as usize;
-                let h2 = (self.geth2(ki.hash) + 2 * self.block_length) as usize;
+                let h1 = (self.get_h1(ki.hash) + self.block_length) as usize;
+                let h2 = (self.get_h2(ki.hash) + 2 * self.block_length) as usize;
                 val ^= self.finger_prints[h1] ^ self.finger_prints[h2];
             } else if ki.index < 2 * self.block_length {
-                let h0 = self.geth0(ki.hash) as usize;
-                let h2 = (self.geth2(ki.hash) + 2 * self.block_length) as usize;
+                let h0 = self.get_h0(ki.hash) as usize;
+                let h2 = (self.get_h2(ki.hash) + 2 * self.block_length) as usize;
                 val ^= self.finger_prints[h0] ^ self.finger_prints[h2];
             } else {
-                let h0 = self.geth0(ki.hash) as usize;
-                let h1 = (self.geth1(ki.hash) + self.block_length) as usize;
+                let h0 = self.get_h0(ki.hash) as usize;
+                let h1 = (self.get_h1(ki.hash) + self.block_length) as usize;
                 val ^= self.finger_prints[h0] ^ self.finger_prints[h1]
             }
             Arc::get_mut(&mut self.finger_prints).unwrap()[ki.index as usize] = val;
@@ -450,12 +453,12 @@ where
             key.hash(&mut hasher);
             hasher.finish()
         };
-        self.contains_key(hashed_key)
+        self.contains_digest(hashed_key)
     }
 
     /// Contains tell you whether the key, as pre-computed digest form, is likely
     /// part of the set, with false positive rate.
-    pub fn contains_key(&self, digest: u64) -> bool {
+    pub fn contains_digest(&self, digest: u64) -> bool {
         let hash = mixsplit(digest, self.seed);
         let f = fingerprint(hash) as u8;
         let r0 = hash as u32;
@@ -477,7 +480,7 @@ impl<H> Xor8<H>
 where
     H: BuildHasher,
 {
-    fn geth0h1h2(&self, k: u64) -> Hashes {
+    fn get_h0h1h2(&self, k: u64) -> Hashes {
         let h = mixsplit(k, self.seed);
         Hashes {
             h,
@@ -487,17 +490,17 @@ where
         }
     }
 
-    fn geth0(&self, hash: u64) -> u32 {
+    fn get_h0(&self, hash: u64) -> u32 {
         let r0 = hash as u32;
         reduce(r0, self.block_length)
     }
 
-    fn geth1(&self, hash: u64) -> u32 {
+    fn get_h1(&self, hash: u64) -> u32 {
         let r1 = hash.rotate_left(21) as u32;
         reduce(r1, self.block_length)
     }
 
-    fn geth2(&self, hash: u64) -> u32 {
+    fn get_h2(&self, hash: u64) -> u32 {
         let r2 = hash.rotate_left(42) as u32;
         reduce(r2, self.block_length)
     }

--- a/src/xor8_test.rs
+++ b/src/xor8_test.rs
@@ -66,7 +66,7 @@ where
             key.hash(&mut hasher);
             hasher.finish()
         };
-        assert!(filter.contains_key(digest), "key {} not present", key);
+        assert!(filter.contains_digest(digest), "key {} not present", key);
     }
 
     // print some statistics
@@ -107,7 +107,9 @@ where
             hasher.finish()
         })
         .collect();
-    filter.build_keys(&digests).expect("failed build_keys");
+    filter
+        .build_from_digests(&digests)
+        .expect("failed build_keys");
 
     // contains api
     for key in keys.iter() {
@@ -115,7 +117,11 @@ where
     }
     // contains_key api
     for digest in digests.into_iter() {
-        assert!(filter.contains_key(digest), "digest {} not present", digest);
+        assert!(
+            filter.contains_digest(digest),
+            "digest {} not present",
+            digest
+        );
     }
 
     // print some statistics
@@ -164,7 +170,9 @@ fn test_xor8_build_keys_simple() {
         })
         .collect();
 
-    filter.build_keys(&digests).expect("failed build_keys");
+    filter
+        .build_from_digests(&digests)
+        .expect("failed build_keys");
 
     // contains api
     for key in keys.iter() {
@@ -173,22 +181,26 @@ fn test_xor8_build_keys_simple() {
 
     // contains_key api
     for digest in digests.into_iter() {
-        assert!(filter.contains_key(digest), "digest {} not present", digest);
+        assert!(
+            filter.contains_digest(digest),
+            "digest {} not present",
+            digest
+        );
     }
 
     // print some statistics
-    let (falsesize, mut matches) = (10_000_000, 0_f64);
+    let (false_size, mut matches) = (10_000_000, 0_f64);
     let bpv = (filter.finger_prints.len() as f64) * 8.0 / (keys.len() as f64);
     println!("test_xor8_build_keys<{}> bits per entry {} bits", name, bpv);
     assert!(bpv < 12.0, "bpv({}) >= 12.0", bpv);
 
-    for _ in 0..falsesize {
+    for _ in 0..false_size {
         if filter.contains(&rng.gen::<u64>()) {
             matches += 1_f64;
         }
     }
 
-    let fpp = matches * 100.0 / (falsesize as f64);
+    let fpp = matches * 100.0 / (false_size as f64);
     println!(
         "test_xor8_build_keys<{}> false positive rate {}%",
         name, fpp


### PR DESCRIPTION

## Changelog

##### Refactor: correct method names: xx_keys should be xx_digests




- Improvement